### PR TITLE
Add the default url in jupyterlab image

### DIFF
--- a/jupyterlabs/jupyter_notebook_config.py
+++ b/jupyterlabs/jupyter_notebook_config.py
@@ -10,3 +10,4 @@ c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
 c.NotebookApp.token = ''
 c.NotebookApp.password = ''
+c.NotebookApp.default_url = '/lab'


### PR DESCRIPTION
With this we can facilitate the user go to the "/lab" path as home page when the notebook is opened from hubserver links