### PR TITLE
Fix cross origin error

### DIFF
--- a/base-notebook/jupyter_notebook_config.py
+++ b/base-notebook/jupyter_notebook_config.py
@@ -13,3 +13,4 @@ c.NotebookApp.tornado_settings = { 'headers': { 'Content-Security-Policy': "chil
 c.NotebookApp.iopub_data_rate_limit=1.0e10
 c.NotebookApp.token=''
 c.NotebookApp.allow_root = True
+c.NotebookApp.allow_origin = '*'


### PR DESCRIPTION
Signed-off-by: Jan Kowalski <jankowalskipraca85@gmail.com>
In the userspace server context we are actually making cross origin calls in jupyter. Which prevents us from creating new notebook or file. We are allowing here all origins.